### PR TITLE
Direct dependency to guava 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .classpath
 .project
 .settings
+.idea
+.DS_STORE

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.cometd.java</groupId>
             <artifactId>cometd-java-client</artifactId>
             <version>3.0.9</version>


### PR DESCRIPTION
Added direct dependency to guava 20, because some project was dependending on guava 18 and it was falling in a bug when parsing date:
[2021-09-07 12:00:58,406] INFO onMessage() - jsonMessage = {"data":{"event":{"createdDate":"2021-09-07T15:00:58.658Z","replayId":5,"type":"updated"},"sobject":{"Due_Date__c":"2021-09-14T00:00:00.000Z","Id":"a1k0m000001EGy9AAG"}},"channel":"/topic/SF-Kafka-DueDate"} (com.github.jcustenborder.kafka.connect.salesforce.TopicChannelMessageListener:48)
java.lang.NoSuchMethodError: 'void com.google.common.base.Preconditions.checkState(boolean, java.lang.String, java.lang.Object)'
	at com.github.jcustenborder.kafka.connect.utils.data.type.BaseDateTypeParser.parseString(BaseDateTypeParser.java:55)
	at com.github.jcustenborder.kafka.connect.utils.data.type.BaseDateTypeParser.parseJsonNode(BaseDateTypeParser.java:66)
	at com.github.jcustenborder.kafka.connect.utils.data.Parser.parseJsonNode(Parser.java:233)
	at com.github.jcustenborder.kafka.connect.salesforce.SObjectHelper.convertStruct(SObjectHelper.java:225)
	at com.github.jcustenborder.kafka.connect.salesforce.SObjectHelper.convert(SObjectHelper.java:242)
	at com.github.jcustenborder.kafka.connect.salesforce.TopicChannelMessageListener.onMessage(TopicChannelMessageListener.java:50)
Preconditions.checkState(null != date, "Could not parse '%s' to java.util.Date", s);